### PR TITLE
fix: relay environment selection and editing issues

### DIFF
--- a/src/app/dashboard-module/domain-module/config/config-detail/config-detail.component.ts
+++ b/src/app/dashboard-module/domain-module/config/config-detail/config-detail.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ViewChild, ElementRef, inject, signal, computed } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild, ElementRef, inject, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { map, takeUntil, startWith } from 'rxjs/operators';
 import { Subject, Observable, BehaviorSubject } from 'rxjs';
@@ -102,11 +102,6 @@ export class ConfigDetailComponent extends DetailComponent implements OnInit, On
   strategiesCreatable = signal(false);
   relayUpdatable = signal(false);
   private readonly configRelay = signal<any>(null);
-  hasRelay = computed(() => {
-    const relay = this.configRelay();
-    const currentEnv = this.currentEnvironmentSignal();
-    return relay?.activated ? relay.activated[currentEnv] !== undefined : false;
-  });
 
   override loading = signal(true);
   loadingStrategies = signal(true);
@@ -281,8 +276,6 @@ export class ConfigDetailComponent extends DetailComponent implements OnInit, On
     setTimeout(() => this.currentTab.set(2), 500);
   }
 
-
-
   addComponent(event: MatChipInputEvent): void {
     if (!this.matAutocomplete.isOpen) {
       const input = event.chipInput.inputElement;
@@ -376,6 +369,12 @@ export class ConfigDetailComponent extends DetailComponent implements OnInit, On
 
     this.config.relay = relay;
     this.configRelay.set(relay);
+  }
+
+  hasRelay() {
+    const relay = this.configRelay();
+    const currentEnv = this.currentEnvironmentSignal();
+    return relay?.activated ? relay.activated[currentEnv] !== undefined : false;
   }
 
   private isMetricDisabled() {

--- a/src/app/dashboard-module/domain-module/config/relay-detail/relay-detail.component.html
+++ b/src/app/dashboard-module/domain-module/config/relay-detail/relay-detail.component.html
@@ -60,7 +60,7 @@
                 <div class="description">
                     @if (config.relay) {
                     <app-environment-config
-                        [selectedEnvName]="currentEnvironment"
+                        [selectedEnvName]="currentEnvironment()"
                         [enable]="envEnable"
                         [domainId]="parent.domainId" 
                         [configuredEnvironments]="config.relay.activated"

--- a/src/app/dashboard-module/domain-module/config/relay-detail/relay-detail.component.ts
+++ b/src/app/dashboard-module/domain-module/config/relay-detail/relay-detail.component.ts
@@ -297,6 +297,11 @@ export class RelayDetailComponent extends DetailComponent implements OnInit, OnD
   }
 
   public updateEnvironmentStatus(env: EnvironmentChangeEvent): void {
+    if (this.editing()) {
+      this.currentStatus.set(env.status);
+      return;
+    }
+
     const configRelayStatus = new ConfigRelayStatus();
     configRelayStatus.activated[env.environmentName] = env.status;
 


### PR DESCRIPTION
Fixes Relay environment that displays no selection for the current environment. The issues was that the `currentEnvironment` was converted to signal but the template was still using the old attribute name.

It also fixes environment selection when adding a new Relay. During the creation, when toggling the environment, the Relay creation process would try to update an incomplete Relay data into Switcher config.