### PR TITLE
fix: prod build failure caused by legacy-peer-deps when prune

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,6 +27,8 @@ jobs:
         run: |
           npm ci
           npm run lint
+          npm run build:prod
+          npm prune --omit=dev --legacy-peer-deps
 
   docker:
     name: Publish Docker Image

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@ COPY ./ /usr/local/app/
 # Install all dependencies, both production and development, build, and remove dev dependencies
 RUN npm ci && \
 	npm run build:prod && \
-	npm prune --omit=dev
+	npm prune --omit=dev --legacy-peer-deps
 
 # ---------- Release ----------
-FROM nginx:1.31.3-alpine-slim
+FROM nginx:1.31.4-alpine-slim
 
 # Copy nginx config file
 RUN rm -rf /usr/share/nginx/html/* && rm -rf /etc/nginx/nginx.conf

--- a/src/app/documentation-module/documentation.module.ts
+++ b/src/app/documentation-module/documentation.module.ts
@@ -1,17 +1,18 @@
 import { NgModule, SecurityContext } from '@angular/core';
-import { MarkdownModule, SANITIZE } from 'ngx-markdown';
+import { provideMarkdown, SANITIZE } from 'ngx-markdown';
 import { DocumentationRoutingModule } from './documentation.routing';
 
 @NgModule({
     imports: [
-        DocumentationRoutingModule,
-        MarkdownModule.forRoot({
-        sanitize: {
-            provide: SANITIZE,
-            useValue: SecurityContext.NONE
-        },
-        }),
-        MarkdownModule.forChild()
+        DocumentationRoutingModule
+    ],
+    providers: [
+        provideMarkdown({
+            sanitize: {
+                provide: SANITIZE,
+                useValue: SecurityContext.NONE
+            },
+        })
     ]
 })
 export class DocumentationModuleModule { }


### PR DESCRIPTION
This pull request introduces improvements to the build process, updates dependencies, and refactors how the Markdown module is provided in the Angular documentation module. The most important changes are grouped below:

**Build process improvements:**

* Updated the build steps in `.github/workflows/master.yml` to include a production build (`npm run build:prod`) and to prune development dependencies with legacy peer dependency support (`npm prune --omit=dev --legacy-peer-deps`).
* Modified the `Dockerfile` to use `npm prune --omit=dev --legacy-peer-deps` for consistency with the workflow, ensuring compatibility with legacy peer dependencies during the Docker build.

**Dependency updates:**

* Upgraded the base Nginx image in the `Dockerfile` from `nginx:1.31.3-alpine-slim` to `nginx:1.31.4-alpine-slim` for security and stability improvements.

**Angular module refactoring:**

* Refactored `DocumentationModuleModule` in `documentation.module.ts` to use the new `provideMarkdown` API for providing the Markdown module, replacing the previous `MarkdownModule.forRoot` and `MarkdownModule.forChild` usage.